### PR TITLE
Make “reset” stop the stopwatch if it is running

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,11 +112,11 @@ modus="new";
 function start()
 {
  if (modus=="running") return;
- interval=setInterval(step,1000);
+ interval=setInterval(redisplay,1000);
  if (modus=="new") startTime=Date.now();
  else              startTime+=(Date.now()-stopTime);
  modus="running";
- step();
+ redisplay();
 }
 
 function stop()
@@ -132,12 +132,12 @@ function reset()
  stopTime=Date.now();
  startTime=Date.now();
  if (modus=="stopped") modus="new";
- step();
+ redisplay();
 }
 
-function step()
+function redisplay()
 {
- nowTime=Math.round((Date.now()-startTime)/1000);
+ var nowTime=Math.round((Date.now()-startTime)/1000);
 
  var h=Math.floor(nowTime/(60*60));
  nowTime-=h*60*60;

--- a/index.html
+++ b/index.html
@@ -131,7 +131,8 @@ function reset()
 {
  stopTime=Date.now();
  startTime=Date.now();
- if (modus=="stopped") modus="new";
+ if (modus=="running") clearInterval(interval);
+ modus="new";
  redisplay();
 }
 


### PR DESCRIPTION
As I wrote [on Lobsters](https://lobste.rs/s/apgqba/yeah_it_s_a_stopwatch/comments/3zskn2#c_3zskn2):

> If I press “reset” while the stopwatch is running, the time goes to 0, but the stopwatch keeps running. All of the physical and virtual stopwatches I have seen put Stop and Reset on the same button, so that the stopwatch is always stopped after hitting Reset. It feels weird that this stopwatch acts differently, so I think you should change it. I can’t think of a reason anyone would want the current behavior.

I also renamed `step()` to `redisplay()`. I am including that with this change, instead of separately, because otherwise it is confusing to have `reset()` call a function named “step” if the stopwatch is supposed to be stopped. When you are not running, you shouldn’t “step” forward any more, but there is no problem with “redisplaying” when not running.
